### PR TITLE
feat: NumberControlとプリセットブレークポイント選択機能の実装（task 4.2）

### DIFF
--- a/src/editor.scss
+++ b/src/editor.scss
@@ -44,3 +44,36 @@
 	width: 100%;
 	justify-content: center;
 }
+
+// Breakpoint settings styles
+.crf-breakpoint-settings {
+	margin-bottom: 12px;
+}
+
+.crf-breakpoint-presets {
+	margin-top: 8px;
+
+	.crf-presets-label {
+		display: block;
+		font-size: 11px;
+		font-weight: 500;
+		color: var(--wp--preset--color--contrast, #1e1e1e);
+		margin-bottom: 6px;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+	}
+
+	.components-button-group {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+
+		.components-button {
+			flex: 0 0 auto;
+			min-width: 50px;
+			font-size: 12px;
+			padding: 4px 8px;
+			height: auto;
+		}
+	}
+}

--- a/src/inspector-controls.tsx
+++ b/src/inspector-controls.tsx
@@ -2,19 +2,27 @@
  * Cover Responsive Focal - Inspector Controls
  */
 
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 import { __ } from '@wordpress/i18n';
 import {
 	PanelBody,
 	Button,
 	SelectControl,
-	TextControl,
+	__experimentalNumberControl as NumberControl,
 	FocalPointPicker,
+	ButtonGroup,
 } from '@wordpress/components';
 import type {
 	ResponsiveFocalControlsProps,
 	ResponsiveFocalPoint,
 } from './types';
-import { MEDIA_QUERY_TYPES, DEFAULTS, type MediaQueryType } from './constants';
+import {
+	MEDIA_QUERY_TYPES,
+	DEFAULTS,
+	BREAKPOINT_PRESETS,
+	VALIDATION,
+	type MediaQueryType,
+} from './constants';
 
 /**
  * Responsive focal point settings UI
@@ -83,9 +91,7 @@ export const ResponsiveFocalControls: React.FC<
 					{ responsiveFocal.map( ( focal, index ) => (
 						<div key={ index } className="crf-focal-point-item">
 							<div className="crf-focal-point-header">
-								<span>
-									{ `${ focal.mediaType }: ${ focal.breakpoint }px` }
-								</span>
+								<span>{ `${ focal.mediaType }: ${ focal.breakpoint }px` }</span>
 								<Button
 									isDestructive
 									isSmall
@@ -109,30 +115,70 @@ export const ResponsiveFocalControls: React.FC<
 								}
 							/>
 
-							<TextControl
-								label={ __(
-									'Breakpoint (px)',
-									'cover-responsive-focal'
-								) }
-								type="number"
-								value={ focal.breakpoint.toString() }
-								onChange={ ( value ) =>
-									updateFocalPoint( index, {
-										breakpoint: Math.max(
-											1,
+							<div className="crf-breakpoint-settings">
+								<NumberControl
+									label={ __(
+										'Breakpoint (px)',
+										'cover-responsive-focal'
+									) }
+									value={ focal.breakpoint }
+									onChange={ ( value ) => {
+										const numValue =
+											typeof value === 'string'
+												? parseInt( value, 10 )
+												: value;
+										const clampedValue = Math.max(
+											VALIDATION.MIN_BREAKPOINT,
 											Math.min(
-												9999,
-												parseInt(
-													value || '768',
-													10
-												) || 768
+												VALIDATION.MAX_BREAKPOINT,
+												numValue || DEFAULTS.BREAKPOINT
 											)
-										),
-									} )
-								}
-								min="1"
-								max="9999"
-							/>
+										);
+										updateFocalPoint( index, {
+											breakpoint: clampedValue,
+										} );
+									} }
+									min={ VALIDATION.MIN_BREAKPOINT }
+									max={ VALIDATION.MAX_BREAKPOINT }
+									step={ 1 }
+								/>
+
+								<div className="crf-breakpoint-presets">
+									<div className="crf-presets-label">
+										{ __(
+											'Presets:',
+											'cover-responsive-focal'
+										) }
+									</div>
+									<ButtonGroup>
+										{ BREAKPOINT_PRESETS.map(
+											( preset ) => (
+												<Button
+													key={ preset.value }
+													variant={
+														focal.breakpoint ===
+														preset.value
+															? 'primary'
+															: 'secondary'
+													}
+													size="small"
+													onClick={ () =>
+														updateFocalPoint(
+															index,
+															{
+																breakpoint:
+																	preset.value,
+															}
+														)
+													}
+												>
+													{ preset.label }
+												</Button>
+											)
+										) }
+									</ButtonGroup>
+								</div>
+							</div>
 
 							{ attributes.url && (
 								<div className="crf-focal-point-picker">


### PR DESCRIPTION
## Summary
task 4.2 「フォーカルポイント設定UIの実装」を完了しました。

### 主な実装内容
- TextControlをNumberControlに変更して数値入力を改善
- プリセットブレークポイント選択機能を追加（320px, 768px, 1024px, 1200px）
- アクティブなプリセットのビジュアルフィードバック（primary/secondary）
- ブレークポイント値の検証とクランプ機能
- 新機能に対応したCSSStyling
- 全てのテストケースをNumberControlに対応
- プリセット機能の新しいテストケースを追加
- 100%テストカバレッジを維持（135+テストケース）

### 技術的な改善点
- `__experimentalNumberControl` を使用した数値入力の改善
- BREAKPOINT_PRESETS配列による一般的なブレークポイント値の提供
- バリデーション機能による入力値の制限（1-9999px）
- 空の値や無効な値に対する適切なフォールバック処理

### テスト
- 全135テストケースがパス✅
- テストカバレッジ100%を維持✅
- ESLintエラーなし✅
- CSSLintエラーなし✅

## Test plan
- [x] NumberControlが正常に動作する
- [x] プリセットボタンが正しく表示される
- [x] アクティブなプリセットが適切にハイライトされる
- [x] プリセットボタンクリックで値が更新される
- [x] バリデーション機能が正常に動作する
- [x] 全テストケースがパス
- [x] ESLint/CSSLintチェックが通過

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ブレークポイント値の入力に数値入力コントロールを導入し、プリセットボタンで簡単にブレークポイントを選択できるようになりました。
  * プリセットボタンの選択状態が視覚的にわかりやすくなりました。

* **スタイル**
  * ブレークポイント設定およびプリセット用の新しいスタイルを追加しました。

* **テスト**
  * 数値入力コントロールおよびプリセットボタンの動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->