### PR TITLE
fix: add \!important to CSS object-position for higher specificity

### DIFF
--- a/cover-responsive-focal.php
+++ b/cover-responsive-focal.php
@@ -110,7 +110,7 @@ function crf_generate_css_rules( $responsive_focal, $fp_id ) {
 		$media_query = sprintf( '(%s: %dpx)', $media_type, $breakpoint );
 
 		$rules .= sprintf(
-			'@media %s { [data-fp-id="%s"] .wp-block-cover__image-background, [data-fp-id="%s"] .wp-block-cover__video-background { object-position: %s%% %s%%; } }',
+			'@media %s { [data-fp-id="%s"] .wp-block-cover__image-background, [data-fp-id="%s"] .wp-block-cover__video-background { object-position: %s%% %s%% !important; } }',
 			$media_query,
 			esc_attr( $fp_id ),
 			esc_attr( $fp_id ),

--- a/tests/php/test-css-generation.php
+++ b/tests/php/test-css-generation.php
@@ -23,7 +23,7 @@ class CRF_CSS_Generation_Test extends WP_UnitTestCase {
         $css = crf_generate_css_rules($responsive_focal, 'test-id');
         
         // 期待する出力を明確に定義
-        $expected_css = '@media (max-width: 767px) { [data-fp-id="test-id"] .wp-block-cover__image-background, [data-fp-id="test-id"] .wp-block-cover__video-background { object-position: 60% 40%; } }';
+        $expected_css = '@media (max-width: 767px) { [data-fp-id="test-id"] .wp-block-cover__image-background, [data-fp-id="test-id"] .wp-block-cover__video-background { object-position: 60% 40% !important; } }';
         
         $this->assertEquals($expected_css, $css);
     }


### PR DESCRIPTION
## Summary
- CSS の object-position プロパティに \!important を追加
- レスポンシブフォーカルポイントがWordPressコアスタイルを上書きできるように修正
- CSS詳細度の問題で object-position が適用されない問題を解決

## 問題
実際の環境でテストしたところ、生成されたCSSの詳細度がWordPressのデフォルトスタイルに負けて、object-positionが適用されていませんでした。

## 解決策
生成されるCSSに `\!important` を追加することで、詳細度を上げてスタイルが確実に適用されるようにしました。

## Test plan
- [x] PHP関数でCSS生成に\!importantが含まれることを確認
- [x] 実際の環境でobject-positionが適用されることを確認
- [x] 既存のテストが適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * レスポンシブ対応のカバー画像・動画の表示位置（object-position）に `!important` を追加し、他のスタイルよりも優先されるようになりました。

* **テスト**
  * CSS出力のテストを `!important` 宣言に対応するよう修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->