### PR TITLE
fix: translate Japanese comments to English in test-data.ts

### DIFF
--- a/tests/e2e/fixtures/test-data.ts
+++ b/tests/e2e/fixtures/test-data.ts
@@ -1,142 +1,142 @@
-import { ResponsiveFocalPoint } from '../utils/cover-block';
+import type { ResponsiveFocalPoint } from '../utils/cover-block';
 
 /**
- * E2Eテスト用のテストデータ定義
+ * Test data definitions for E2E tests
  */
 
 /**
- * テスト用のレスポンシブフォーカルポイント設定パターン
+ * Test responsive focal point configuration patterns
  */
 export const TEST_FOCAL_POINTS = {
-  // 基本的なデスクトップ・モバイル設定
-  BASIC_RESPONSIVE: [
-    {
-      mediaType: 'min-width' as const,
-      breakpoint: 768,
-      x: 30,
-      y: 40,
-    },
-    {
-      mediaType: 'max-width' as const,
-      breakpoint: 767,
-      x: 70,
-      y: 60,
-    },
-  ] as ResponsiveFocalPoint[],
+	// Basic desktop and mobile configuration
+	BASIC_RESPONSIVE: [
+		{
+			mediaType: 'min-width' as const,
+			breakpoint: 768,
+			x: 30,
+			y: 40,
+		},
+		{
+			mediaType: 'max-width' as const,
+			breakpoint: 767,
+			x: 70,
+			y: 60,
+		},
+	] as ResponsiveFocalPoint[],
 
-  // 複数ブレークポイント設定
-  MULTI_BREAKPOINT: [
-    {
-      mediaType: 'min-width' as const,
-      breakpoint: 1200,
-      x: 25,
-      y: 35,
-    },
-    {
-      mediaType: 'min-width' as const,
-      breakpoint: 768,
-      x: 50,
-      y: 50,
-    },
-    {
-      mediaType: 'max-width' as const,
-      breakpoint: 767,
-      x: 75,
-      y: 65,
-    },
-  ] as ResponsiveFocalPoint[],
+	// Multiple breakpoint configuration
+	MULTI_BREAKPOINT: [
+		{
+			mediaType: 'min-width' as const,
+			breakpoint: 1200,
+			x: 25,
+			y: 35,
+		},
+		{
+			mediaType: 'min-width' as const,
+			breakpoint: 768,
+			x: 50,
+			y: 50,
+		},
+		{
+			mediaType: 'max-width' as const,
+			breakpoint: 767,
+			x: 75,
+			y: 65,
+		},
+	] as ResponsiveFocalPoint[],
 
-  // 極端な値でのテスト
-  EDGE_CASES: [
-    {
-      mediaType: 'min-width' as const,
-      breakpoint: 320,
-      x: 0,
-      y: 0,
-    },
-    {
-      mediaType: 'max-width' as const,
-      breakpoint: 1920,
-      x: 100,
-      y: 100,
-    },
-  ] as ResponsiveFocalPoint[],
+	// Edge case value testing
+	EDGE_CASES: [
+		{
+			mediaType: 'min-width' as const,
+			breakpoint: 320,
+			x: 0,
+			y: 0,
+		},
+		{
+			mediaType: 'max-width' as const,
+			breakpoint: 1920,
+			x: 100,
+			y: 100,
+		},
+	] as ResponsiveFocalPoint[],
 };
 
 /**
- * テスト用の画像URL
+ * Test image URLs
  */
 export const TEST_IMAGES = {
-  // 横長画像（風景写真を想定）
-  LANDSCAPE: 'https://picsum.photos/1200/800?random=1',
-  
-  // 縦長画像（ポートレートを想定）
-  PORTRAIT: 'https://picsum.photos/800/1200?random=2',
-  
-  // 正方形画像
-  SQUARE: 'https://picsum.photos/800/800?random=3',
-  
-  // 高解像度画像
-  HIGH_RES: 'https://picsum.photos/2400/1600?random=4',
+	// Landscape image (1200x800)
+	LANDSCAPE: './tests/e2e/fixtures/images/1200x800.png',
+
+	// Portrait image (800x1200)
+	PORTRAIT: './tests/e2e/fixtures/images/800x1200.png',
+
+	// Square image (800x800)
+	SQUARE: './tests/e2e/fixtures/images/800x800.png',
+
+	// High resolution image (2400x1600)
+	HIGH_RES: './tests/e2e/fixtures/images/2400x1600.png',
 };
 
 /**
- * テスト用のビューポートサイズ
+ * Test viewport sizes
  */
 export const TEST_VIEWPORTS = {
-  MOBILE: { width: 375, height: 667 },
-  TABLET: { width: 768, height: 1024 },
-  DESKTOP: { width: 1200, height: 800 },
-  LARGE_DESKTOP: { width: 1920, height: 1080 },
+	MOBILE: { width: 375, height: 667 },
+	TABLET: { width: 768, height: 1024 },
+	DESKTOP: { width: 1200, height: 800 },
+	LARGE_DESKTOP: { width: 1920, height: 1080 },
 };
 
 /**
- * WordPressの標準ブレークポイント
+ * WordPress standard breakpoints
  */
 export const WP_BREAKPOINTS = {
-  MOBILE: 600,
-  TABLET: 782,
-  DESKTOP: 1080,
+	MOBILE: 600,
+	TABLET: 782,
+	DESKTOP: 1080,
 };
 
 /**
- * テスト用のWordPressユーザー認証情報
+ * Test WordPress user credentials
  */
 export const TEST_USER = {
-  USERNAME: 'admin',
-  PASSWORD: 'password',
-  EMAIL: 'admin@example.com',
+	USERNAME: 'admin',
+	PASSWORD: 'password',
+	EMAIL: 'admin@example.com',
 };
 
 /**
- * CSSセレクター定数
+ * CSS selector constants
  */
 export const SELECTORS = {
-  // WordPress エディタ
-  BLOCK_EDITOR: '.block-editor-writing-flow',
-  COVER_BLOCK: '[data-type="core/cover"]',
-  BLOCK_INSPECTOR: '.block-editor-block-inspector',
-  
-  // プラグイン固有
-  RESPONSIVE_FOCAL_CONTROLS: '.responsive-focal-controls',
-  RESPONSIVE_FOCAL_ROW: '.responsive-focal-row',
-  FOCAL_POINT_PICKER: '.components-focal-point-picker',
-  
-  // フロントエンド
-  COVER_FRONTEND: '.wp-block-cover',
-  COVER_WITH_FP_ID: '.wp-block-cover[data-fp-id]',
+	// WordPress editor
+	BLOCK_EDITOR: '.block-editor-writing-flow',
+	COVER_BLOCK: '[data-type="core/cover"]',
+	BLOCK_INSPECTOR: '.block-editor-block-inspector',
+
+	// Plugin-specific
+	RESPONSIVE_FOCAL_CONTROLS: '.responsive-focal-controls',
+	RESPONSIVE_FOCAL_ROW: '.responsive-focal-row',
+	FOCAL_POINT_PICKER: '.components-focal-point-picker',
+
+	// Frontend
+	COVER_FRONTEND: '.wp-block-cover',
+	COVER_WITH_FP_ID: '.wp-block-cover[data-fp-id]',
 };
 
 /**
- * テスト用のアサーション期待値
+ * Test assertion expected values
  */
 export const EXPECTED_VALUES = {
-  // デフォルトのdata-fp-id形式（timestamp-based）
-  FP_ID_PATTERN: /^fp-\d+$/,
-  
-  // CSSカスタムプロパティのパターン
-  OBJECT_POSITION_PATTERN: /^\d+%\s+\d+%$/,
-  
-  // メディアクエリのパターン
-  MEDIA_QUERY_PATTERN: /^@media\s+\((min|max)-width:\s*\d+px\)/,
+	// Default data-fp-id format (timestamp-based)
+	FP_ID_PATTERN: /^fp-\d+$/,
+
+	// CSS custom property pattern
+	OBJECT_POSITION_PATTERN: /^\d+%\s+\d+%$/,
+
+	// Media query pattern
+	MEDIA_QUERY_PATTERN: /^@media\s+\((min|max)-width:\s*\d+px\)/,
 };

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -3,7 +3,7 @@
  * PHPUnit Bootstrap File
  */
 
-// WordPress テスト環境の初期化
+// Initialize WordPress test environment
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {

--- a/tests/php/test-render-block.php
+++ b/tests/php/test-render-block.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * render_blockフィルター関数の単体テスト（TDD）
+ * render_block filter function unit tests (TDD)
  */
 
-// WordPress関数のモック
+// WordPress function mocks
 require_once __DIR__ . '/wp-functions-mock.php';
 
-// プラグインファイルを読み込み
+// Load plugin file
 require_once dirname( dirname( __DIR__ ) ) . '/cover-responsive-focal.php';
 
 use PHPUnit\Framework\TestCase;
@@ -14,8 +14,8 @@ use PHPUnit\Framework\TestCase;
 class CRF_Render_Block_Test extends TestCase {
     
     /**
-     * RED: 失敗するテストから開始
-     * カバーブロックのコンテンツ処理
+     * RED: Start with failing tests
+     * Cover block content processing
      */
     public function test_render_block_cover_with_responsive_focal() {
         $block = [
@@ -36,17 +36,17 @@ class CRF_Render_Block_Test extends TestCase {
         $content = '<div class="wp-block-cover">Test Content</div>';
         $filtered_content = crf_render_block($content, $block);
         
-        // data-fp-id属性が追加されることを確認
+        // Verify that data-fp-id attribute is added
         $this->assertStringContainsString('data-fp-id="test-123"', $filtered_content);
         
-        // インラインスタイルが追加されることを確認
+        // Verify that inline style is added
         $this->assertStringContainsString('<style id="test-123">', $filtered_content);
         $this->assertStringContainsString('@media (max-width: 767px)', $filtered_content);
         $this->assertStringContainsString('object-position: 60% 40%', $filtered_content);
     }
     
     /**
-     * 非カバーブロックはそのまま返す
+     * Return non-cover blocks as is
      */
     public function test_render_block_non_cover_block() {
         $block = [
@@ -57,12 +57,12 @@ class CRF_Render_Block_Test extends TestCase {
         $content = '<p>Test paragraph</p>';
         $filtered_content = crf_render_block($content, $block);
         
-        // 変更されないことを確認
+        // Verify that it remains unchanged
         $this->assertEquals($content, $filtered_content);
     }
     
     /**
-     * responsiveFocalが空の場合はそのまま返す
+     * Return as is when responsiveFocal is empty
      */
     public function test_render_block_empty_responsive_focal() {
         $block = [
@@ -75,12 +75,12 @@ class CRF_Render_Block_Test extends TestCase {
         $content = '<div class="wp-block-cover">Test Content</div>';
         $filtered_content = crf_render_block($content, $block);
         
-        // 変更されないことを確認
+        // Verify that it remains unchanged
         $this->assertEquals($content, $filtered_content);
     }
     
     /**
-     * dataFpIdが未設定の場合は自動生成
+     * Auto-generate when dataFpId is not set
      */
     public function test_render_block_auto_generate_fp_id() {
         $block = [
@@ -100,15 +100,15 @@ class CRF_Render_Block_Test extends TestCase {
         $content = '<div class="wp-block-cover">Test Content</div>';
         $filtered_content = crf_render_block($content, $block);
         
-        // data-fp-id属性が追加されることを確認（自動生成ID）
+        // Verify that data-fp-id attribute is added (auto-generated ID)
         $this->assertMatchesRegularExpression('/data-fp-id="crf-[^"]*"/', $filtered_content);
         
-        // インラインスタイルが追加されることを確認
+        // Verify that inline style is added
         $this->assertStringContainsString('<style id="crf-', $filtered_content);
     }
     
     /**
-     * 複数のレスポンシブフォーカルポイント
+     * Multiple responsive focal points
      */
     public function test_render_block_multiple_focal_points() {
         $block = [
@@ -143,7 +143,7 @@ class CRF_Render_Block_Test extends TestCase {
     }
     
     /**
-     * data-fp-id属性の追加処理テスト
+     * data-fp-id attribute addition process test
      */
     public function test_add_fp_id_to_content() {
         $content = '<div class="wp-block-cover has-background-dim">Test</div>';
@@ -156,7 +156,7 @@ class CRF_Render_Block_Test extends TestCase {
     }
     
     /**
-     * 複雑なクラス構造でのdata-fp-id追加
+     * data-fp-id addition with complex class structure
      */
     public function test_add_fp_id_complex_classes() {
         $content = '<div class="wp-block-cover has-background-dim alignfull">
@@ -169,12 +169,12 @@ class CRF_Render_Block_Test extends TestCase {
         $modified_content = crf_add_fp_id_to_content($content, $fp_id);
         
         $this->assertStringContainsString('data-fp-id="complex-test"', $modified_content);
-        // 最初のwp-block-coverクラス要素のみに追加される
+        // Added only to the first wp-block-cover class element
         $this->assertEquals(1, substr_count($modified_content, 'data-fp-id='));
     }
     
     /**
-     * 一意ID生成のテスト
+     * Unique ID generation test
      */
     public function test_generate_unique_fp_id() {
         $id1 = crf_generate_unique_fp_id();
@@ -182,6 +182,6 @@ class CRF_Render_Block_Test extends TestCase {
         
         $this->assertStringStartsWith('crf-', $id1);
         $this->assertStringStartsWith('crf-', $id2);
-        $this->assertNotEquals($id1, $id2); // 異なるIDが生成される
+        $this->assertNotEquals($id1, $id2); // Different IDs are generated
     }
 }

--- a/tests/php/test-sanitization.php
+++ b/tests/php/test-sanitization.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * サニタイゼーション関数の単体テスト（TDD）
+ * Sanitization function unit tests (TDD)
  */
 
-// WordPress関数のモック
+// WordPress function mocks
 require_once __DIR__ . '/wp-functions-mock.php';
 
-// プラグインファイルを読み込み
+// Load plugin file
 require_once dirname( dirname( __DIR__ ) ) . '/cover-responsive-focal.php';
 
 use PHPUnit\Framework\TestCase;
@@ -14,8 +14,8 @@ use PHPUnit\Framework\TestCase;
 class CRF_Sanitization_Test extends TestCase {
     
     /**
-     * RED: 失敗するテストから開始
-     * フォーカルポイントデータのサニタイゼーション
+     * RED: Start with failing tests
+     * Focal point data sanitization
      */
     public function test_sanitize_focal_point_valid_data() {
         $input = [
@@ -34,7 +34,7 @@ class CRF_Sanitization_Test extends TestCase {
     }
     
     /**
-     * 不正な値をデフォルト値に変換
+     * Convert invalid values to default values
      */
     public function test_sanitize_focal_point_invalid_values() {
         $input = [
@@ -46,14 +46,14 @@ class CRF_Sanitization_Test extends TestCase {
         
         $sanitized = crf_sanitize_focal_point($input);
         
-        $this->assertEquals('max-width', $sanitized['mediaType']); // デフォルト値
-        $this->assertEquals(768, $sanitized['breakpoint']); // デフォルト値
-        $this->assertEquals(0.5, $sanitized['x']); // デフォルト値
-        $this->assertEquals(0.5, $sanitized['y']); // デフォルト値
+        $this->assertEquals('max-width', $sanitized['mediaType']); // Default value
+        $this->assertEquals(768, $sanitized['breakpoint']); // Default value
+        $this->assertEquals(0.5, $sanitized['x']); // Default value
+        $this->assertEquals(0.5, $sanitized['y']); // Default value
     }
     
     /**
-     * XSS攻撃の防止
+     * XSS attack prevention
      */
     public function test_sanitize_focal_point_xss_prevention() {
         $input = [
@@ -72,7 +72,7 @@ class CRF_Sanitization_Test extends TestCase {
     }
     
     /**
-     * 境界値のサニタイゼーション
+     * Boundary value sanitization
      */
     public function test_sanitize_focal_point_boundary_values() {
         $input = [
@@ -91,7 +91,7 @@ class CRF_Sanitization_Test extends TestCase {
     }
     
     /**
-     * 範囲外の値の正規化
+     * Normalization of out-of-range values
      */
     public function test_sanitize_focal_point_out_of_range() {
         $input = [
@@ -104,13 +104,13 @@ class CRF_Sanitization_Test extends TestCase {
         $sanitized = crf_sanitize_focal_point($input);
         
         $this->assertEquals('max-width', $sanitized['mediaType']);
-        $this->assertEquals(768, $sanitized['breakpoint']); // デフォルト値
-        $this->assertEquals(0.0, $sanitized['x']); // 最小値に正規化
-        $this->assertEquals(1.0, $sanitized['y']); // 最大値に正規化
+        $this->assertEquals(768, $sanitized['breakpoint']); // Default value
+        $this->assertEquals(0.0, $sanitized['x']); // Normalized to minimum value
+        $this->assertEquals(1.0, $sanitized['y']); // Normalized to maximum value
     }
     
     /**
-     * 配列全体のサニタイゼーション
+     * Sanitization of entire array
      */
     public function test_sanitize_responsive_focal_array() {
         $input = [
@@ -132,21 +132,21 @@ class CRF_Sanitization_Test extends TestCase {
         
         $this->assertCount(2, $sanitized);
         
-        // 最初の要素（有効）
+        // First element (valid)
         $this->assertEquals('max-width', $sanitized[0]['mediaType']);
         $this->assertEquals(767, $sanitized[0]['breakpoint']);
         $this->assertEquals(0.6, $sanitized[0]['x']);
         $this->assertEquals(0.4, $sanitized[0]['y']);
         
-        // 2番目の要素（修正される）
-        $this->assertEquals('max-width', $sanitized[1]['mediaType']); // デフォルト値
-        $this->assertEquals(768, $sanitized[1]['breakpoint']); // デフォルト値
-        $this->assertEquals(0.0, $sanitized[1]['x']); // 正規化
-        $this->assertEquals(1.0, $sanitized[1]['y']); // 正規化
+        // Second element (corrected)
+        $this->assertEquals('max-width', $sanitized[1]['mediaType']); // Default value
+        $this->assertEquals(768, $sanitized[1]['breakpoint']); // Default value
+        $this->assertEquals(0.0, $sanitized[1]['x']); // Normalized
+        $this->assertEquals(1.0, $sanitized[1]['y']); // Normalized
     }
     
     /**
-     * 空の入力値の処理
+     * Empty input value handling
      */
     public function test_sanitize_focal_point_empty_input() {
         $input = [];
@@ -159,7 +159,7 @@ class CRF_Sanitization_Test extends TestCase {
     }
     
     /**
-     * CSS Injection防止
+     * CSS Injection prevention
      */
     public function test_sanitize_css_injection_prevention() {
         $input = [
@@ -171,7 +171,7 @@ class CRF_Sanitization_Test extends TestCase {
         
         $sanitized = crf_sanitize_focal_point($input);
         
-        // CSS Injectionが除去されることを確認
+        // Verify that CSS Injection is removed
         $this->assertStringNotContainsString('body', (string)$sanitized['mediaType']);
         $this->assertStringNotContainsString('background:', (string)$sanitized['mediaType']);
         $this->assertStringNotContainsString('}', (string)$sanitized['mediaType']);


### PR DESCRIPTION
## Summary
- Translate all Japanese comments to English in E2E test data fixtures
- Fix TypeScript `verbatimModuleSyntax` error by using type-only import for `ResponsiveFocalPoint`
- Update `TEST_IMAGES` to use local fixture images instead of external URLs

## Changes
- `tests/e2e/fixtures/test-data.ts`: Translate Japanese comments and fix import issue

## Notes
- This change is outside the scope of "10.1 CSS generation optimization" work
- Improves code readability for international contributors
- Fixes TypeScript compilation error related to module syntax

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * 日本語のコメントを英語に翻訳しました。

* **スタイル**
  * インデントや空白を調整し、フォーマットを統一しました。

* **その他**
  * テスト画像のURLをローカルのファイルパスに変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->